### PR TITLE
Update index.mdx

### DIFF
--- a/website/docs/cli/code/index.mdx
+++ b/website/docs/cli/code/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Writing and Modifying Terraform Code
 
-The [Terraform language](/terraform/language) is Terraform's primary
+The [Terraform language](https://github.com/hashicorp/terraform/tree/main/website/docs/language) is Terraform's primary
 user interface, and all of Terraform's workflows rely on configurations written
 in the Terraform language.
 
@@ -15,17 +15,17 @@ Terraform CLI includes several commands to make Terraform code more convenient
 to work with. Integrating these commands into your editing workflow can
 potentially save you time and effort.
 
-- [The `terraform console` command](/terraform/cli/commands/console) starts an
+- [The `terraform console` command](https://github.com/hashicorp/terraform/blob/main/website/docs/cli/commands/console.mdx)   starts an
   interactive shell for evaluating Terraform
-  [expressions](/terraform/language/expressions), which can be a faster way
+  [expressions](https://github.com/hashicorp/terraform/tree/main/website/docs/language/expressions), which can be a faster   way
   to verify that a particular resource argument results in the value you expect.
 
-- [The `terraform fmt` command](/terraform/cli/commands/fmt) rewrites Terraform
+- [The `terraform fmt` command](https://github.com/hashicorp/terraform/blob/28643516b229e5542e3943893fe4c1ed15fba48e/website/docs/cli/commands/fmt.mdx)     rewrites Terraform
   configuration files to a canonical format and style, so you don't have to
   waste time making minor adjustments for readability and consistency. It works
   well as a pre-commit hook in your version control system.
 
-- [The `terraform validate` command](/terraform/cli/commands/validate) validates the
+- [The `terraform validate` command](https://github.com/hashicorp/terraform/blob/28643516b229e5542e3943893fe4c1ed15fba48e/website/docs/cli/commands/validate.mdx)validates the
   syntax and arguments of the Terraform configuration files in a directory,
   including argument and attribute names and types for resources and modules.
   The `plan` and `apply` commands automatically validate a configuration before
@@ -33,12 +33,12 @@ potentially save you time and effort.
   workflow, but it can be very useful as a pre-commit hook or as part of a
   continuous integration pipeline.
 
-- [The `0.13upgrade` command](/terraform/cli/commands/0.13upgrade) and
-  [the `0.12upgrade` command](/terraform/cli/commands/0.12upgrade) can automatically
+- [The `0.13upgrade` command](https://github.com/hashicorp/terraform/blob/28643516b229e5542e3943893fe4c1ed15fba48e/website/docs/cli/commands/0.13upgrade.mdx) and
+  [the `0.12upgrade` command](https://github.com/hashicorp/terraform/blob/28643516b229e5542e3943893fe4c1ed15fba48e/website/docs/cli/commands/0.12upgrade.mdx) can automatically
   modify the configuration files in a Terraform module to help deal with major
   syntax changes that occurred in the 0.13 and 0.12 releases of Terraform. Both
   of these commands are only available in the Terraform version they are
   associated with, and you are expected to upgrade older code to be compatible
   with 0.12 before attempting to make it compatible with 0.13. For more detailed
   information about updating code for new Terraform versions, see the [upgrade
-  guides](/terraform/language/upgrade-guides) in the Terraform language docs.
+  guides](https://github.com/hashicorp/terraform/blob/28643516b229e5542e3943893fe4c1ed15fba48e/website/docs/language/upgrade-guides/index.mdx) in the Terraform language docs.


### PR DESCRIPTION

Solve the 404 "The main branch of terraform does not contain the path" problem by setting it with the right links.  If you set the path the link dont show up.

User could go without any problem to the links in the doc and open it. (will be forwarded to the right section)


